### PR TITLE
Added Svelte to single spa jsatf app 

### DIFF
--- a/jsallthefrontends/index.html
+++ b/jsallthefrontends/index.html
@@ -3,5 +3,6 @@
     <h2>JS All the Frontends</h2>
     <div id="react"></div>
     <div id="vue"></div>
+    <div id="svelte"></div>
   </body>
 </html>

--- a/jsallthefrontends/package-lock.json
+++ b/jsallthefrontends/package-lock.json
@@ -8220,6 +8220,11 @@
       "resolved": "https://registry.npmjs.org/single-spa-react/-/single-spa-react-3.1.0.tgz",
       "integrity": "sha512-dzSAFk0W3bNf0B3fvyjgji7ukBn8L4erHCBqbU7hgqrwu88ro8pqcWDJKugQPruRp3dceSXunMw4n9epzE1t8w=="
     },
+    "single-spa-svelte": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/single-spa-svelte/-/single-spa-svelte-2.1.0.tgz",
+      "integrity": "sha512-9g1Mqt4QPmpetqQRhKPUnqXVAjbrvQCSA/kowcUj7nmYeyPWJvxzNC7vOkVZBsSo8GVJlNKmss+UvK5cc3UoGg=="
+    },
     "single-spa-vue": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/single-spa-vue/-/single-spa-vue-1.10.1.tgz",
@@ -8770,6 +8775,27 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "svelte": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.29.0.tgz",
+      "integrity": "sha512-f+A65eyOQ5ujETLy+igNXtlr6AEjAQLYd1yJE1VwNiXMQO5Z/Vmiy3rL+zblV/9jd7rtTTWqO1IcuXsP2Qv0OA=="
+    },
+    "svelte-dev-helper": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/svelte-dev-helper/-/svelte-dev-helper-1.1.9.tgz",
+      "integrity": "sha1-fRh9tcbNu9ZNdaMvkbiZi94yc8M=",
+      "dev": true
+    },
+    "svelte-loader": {
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/svelte-loader/-/svelte-loader-2.13.6.tgz",
+      "integrity": "sha512-7uf7ZQdPAl+lwb1ldUYJFY/raZRUCuaNx7lMJ+F16jrVwN1+c35C2pBMGIY0mCqdKm5sm45jqELJJLGM3UG9Pw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "svelte-dev-helper": "^1.1.9"
       }
     },
     "table-layout": {

--- a/jsallthefrontends/package.json
+++ b/jsallthefrontends/package.json
@@ -15,7 +15,9 @@
     "react-dom": "^16.14.0",
     "single-spa": "^5.8.0",
     "single-spa-react": "^3.1.0",
+    "single-spa-svelte": "^2.1.0",
     "single-spa-vue": "^1.10.1",
+    "svelte": "^3.29.0",
     "vue": "^2.6.12"
   },
   "devDependencies": {
@@ -30,6 +32,7 @@
     "html-loader": "^1.3.2",
     "html-webpack-plugin": "^4.5.0",
     "style-loader": "^2.0.0",
+    "svelte-loader": "^2.13.6",
     "vue-loader": "^15.9.3",
     "vue-template-compiler": "^2.6.12",
     "webpack": "^5.1.3",

--- a/jsallthefrontends/single-spa.config.js
+++ b/jsallthefrontends/single-spa.config.js
@@ -12,4 +12,10 @@ registerApplication({
   activeWhen: "/vue",
 });
 
+registerApplication({
+  name: "svelte",
+  app: () => import("./src/svelte/svelte.app.js"),
+  activeWhen: "/svelte",
+});
+
 start();

--- a/jsallthefrontends/src/svelte/App.svelte
+++ b/jsallthefrontends/src/svelte/App.svelte
@@ -1,0 +1,8 @@
+<script>
+  console.log("over here in svelte!");
+</script>
+
+<style>
+</style>
+
+<h1>Hello from a Svelte file</h1>

--- a/jsallthefrontends/src/svelte/svelte.app.js
+++ b/jsallthefrontends/src/svelte/svelte.app.js
@@ -1,0 +1,14 @@
+import singleSpaSvelte from "single-spa-svelte";
+import App from "./App.svelte";
+
+function domElementGetter() {
+  return document.getElementById("svelte");
+}
+
+const svelteLifecycles = singleSpaSvelte({
+  component: App,
+  domElementGetter,
+});
+export const bootstrap = svelteLifecycles.bootstrap;
+export const mount = svelteLifecycles.mount;
+export const unmount = svelteLifecycles.unmount;

--- a/jsallthefrontends/webpack.config.js
+++ b/jsallthefrontends/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /(node_modules)/,
+        exclude: /node_modules/,
         use: {
           loader: "babel-loader",
           options: {
@@ -29,6 +29,11 @@ module.exports = {
         loader: "vue-loader",
       },
       {
+        test: /\.svelte$/,
+        exclude: /node_modules/,
+        use: "svelte-loader",
+      },
+      {
         test: /\.css$/,
         use: ["style-loader", "css-loader"],
       },
@@ -37,12 +42,14 @@ module.exports = {
   resolve: {
     alias: {
       vue: "vue/dist/vue.js",
+      svelte: path.resolve("node_modules", "svelte"),
     },
+    mainFields: ["svelte", "browser", "module", "main"],
     modules: [path.resolve(__dirname, "node_modules")],
     fallback: {
       fs: false,
     },
-    extensions: [".js", ".json", ".jsx", ".vue", ".css"],
+    extensions: [".mjs", ".js", ".json", ".jsx", ".vue", ".svelte", ".css"],
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Installed svelte, svelte-loader, single-spa-svelte to use svelte inside jsatf. Modified webpack config with svelte loader rule